### PR TITLE
NO JIRA. Goal that adds a helper script to target

### DIFF
--- a/src/main/java/nl/knaw/dans/maven/buildresources/GetHelperScriptMojo.java
+++ b/src/main/java/nl/knaw/dans/maven/buildresources/GetHelperScriptMojo.java
@@ -1,0 +1,42 @@
+package nl.knaw.dans.maven.buildresources;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Mojo(name = "get-helper-script", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+public class GetHelperScriptMojo extends AbstractMojo {
+
+    @Parameter(name = "helper", required = true, defaultValue = "add-swagger-ui.sh")
+    private String helper;
+
+    /**
+     * Directory in which to place the license header template.
+     */
+    @Parameter(name = "targetDir", required = true, defaultValue = "${project.build.directory}")
+    private File targetDir;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        try {
+            getLog().info(String.format("Copying helper script %s to %s", helper, targetDir));
+            var script = IOUtils.resourceToString(String.format("/helper-scripts/%s", helper), StandardCharsets.UTF_8);
+            var outputFile = targetDir.toPath().resolve(helper);
+            FileUtils.createParentDirectories(outputFile.toFile());
+            FileUtils.writeStringToFile(outputFile.toFile(), script, StandardCharsets.UTF_8);
+        }
+        catch (IOException e) {
+            throw new MojoExecutionException("Could not read add-swagger-ui.sh from resources", e);
+        }
+
+    }
+}

--- a/src/main/resources/helper-scripts/add-swagger-ui.sh
+++ b/src/main/resources/helper-scripts/add-swagger-ui.sh
@@ -1,0 +1,35 @@
+SWAGGER_UI_VERSION=5.3.1
+
+echo "Removing previously downloaded swagger-ui if present..."
+if [ -d "target/swagger-ui" ]; then rm -fr target/swagger-ui; fi
+echo -n "Downloading swagger-ui..."
+mvn dependency:get -Dartifact=org.webjars:swagger-ui:$SWAGGER_UI_VERSION -Ddest=target/swagger-ui.zip
+echo "OK"
+echo "Removing existing swagger-ui if present..."
+if [ -d "docs/swagger-ui" ]; then rm -fr docs/swagger-ui; fi
+echo -n "Unzipping swagger-ui..."
+unzip -q target/swagger-ui.zip -d target/swagger-ui
+echo "OK"
+echo -n "Copying the relevant files to docs/swagger-ui..."
+cp -r target/swagger-ui/META-INF/resources/webjars/swagger-ui/$SWAGGER_UI_VERSION docs/swagger-ui
+echo "OK"
+echo "Patching the index.css"
+echo -n "  - removing the top bar..."
+sed -i -e '$a.topbar { display: none; }' docs/swagger-ui/index.css
+echo "OK"
+echo -n "  - removing the link to api.yml..."
+sed -i -e '$a.link { display: none; }' docs/swagger-ui/index.css
+echo "OK"
+echo -m "  - removing the try it out button..."
+sed -i -e '$a.try-out { display: none; }' docs/swagger-ui/index.css
+echo "OK"
+echo "Patching swagger-initializer.js"
+echo " - replace link to petstore with ../api.yml"
+sed -i -e 's#https://petstore.swagger.io/v2/swagger.json#../api.yml#' docs/swagger-ui/swagger-initializer.js
+echo "OK"
+
+echo "DONE"
+
+
+
+


### PR DESCRIPTION
NO JIRA

# Description of changes
Added the goal `get-helper-script` that will output the helper script  `add-swagger-ui.sh` to `target` by default. This helper script can then be used by the docs.yml workflow to add a patched Swagger UI for rendering the microservice's Open API service definition.


@DANS-KNAW/dataversedans
